### PR TITLE
Add failure for silent pass of fail-tests

### DIFF
--- a/contracts/test/allowlist.test.ts
+++ b/contracts/test/allowlist.test.ts
@@ -95,6 +95,7 @@ describe("AllowlistPaymaster", function () {
   it("should prevent non-owners from withdrawing funds", async function () {
     try {
       await paymaster.connect(userWallet).withdraw(userWallet.address);
+      throw new Error("Should not be able to withdraw funds");
     } catch (e) {
       expect(e.message).to.include("Ownable: caller is not the owner");
     }
@@ -104,6 +105,7 @@ describe("AllowlistPaymaster", function () {
     const notAllowedWallet = Wallet.createRandom().connect(provider);
     try {
       await executeGreetingTransaction(notAllowedWallet);
+      throw new Error("Should not be able to call Greeter");
     } catch (e) {
       expect(e.message).to.include("Account is not in allow list");
     }

--- a/contracts/test/erc20fixed.test.ts
+++ b/contracts/test/erc20fixed.test.ts
@@ -116,6 +116,7 @@ describe("ERC20fixedPaymaster", function () {
   it("should prevent non-owners from withdrawing funds", async function () {
     try {
       await paymaster.connect(userWallet).withdraw(userWallet.address);
+      throw new Error("Should not be able to withdraw funds");
     } catch (e) {
       expect(e.message).to.include("Ownable: caller is not the owner");
     }

--- a/contracts/test/erc721gated.test.ts
+++ b/contracts/test/erc721gated.test.ts
@@ -101,6 +101,7 @@ describe("ERC721gatedPaymaster", function () {
   it("should prevent non-owners from withdrawing funds", async function () {
     try {
       await paymaster.connect(userWallet).withdraw(userWallet.address);
+      throw new Error("Should not be able to withdraw funds");
     } catch (e) {
       expect(e.message).to.include("Ownable: caller is not the owner");
     }

--- a/contracts/test/gasless.test.ts
+++ b/contracts/test/gasless.test.ts
@@ -90,6 +90,7 @@ describe("GaslessPaymaster", function () {
   it("should prevent non-owners from withdrawing funds", async function () {
     try {
       await paymaster.connect(userWallet).withdraw(userWallet.address);
+      throw new Error("Should not be able to withdraw funds");
     } catch (e) {
       expect(e.message).to.include("Ownable: caller is not the owner");
     }

--- a/frontend/src/components/PaymasterMessage.js
+++ b/frontend/src/components/PaymasterMessage.js
@@ -13,21 +13,99 @@ const PaymasterMessage = ({
 
   switch (selectedPaymaster) {
     case "Allowlist Paymaster 📜":
-      message =
-       <> <p>You've selected the Allowlist Paymaster. Let's see if you are on the list! 📜</p> <br/><p className="flex-wrap max-w-4xl	">The Allowlist Paymaster uses the <span className="font-bold">general paymaster flow</span> which should be used if no prior actions are required from the user for the paymaster to operate. For more information, proceed to our docs <a className="text-cyan-400" href="https://era.zksync.io/docs/reference/concepts/aa.html#general-paymaster-flow">here.</a></p></>;
+      message = (
+        <>
+          {" "}
+          <p>
+            You've selected the Allowlist Paymaster. Let's see if you are on the
+            list! 📜
+          </p>{" "}
+          <br />
+          <p className="flex-wrap max-w-4xl	">
+            The Allowlist Paymaster uses the{" "}
+            <span className="font-bold">general paymaster flow</span> which
+            should be used if no prior actions are required from the user for
+            the paymaster to operate. For more information, proceed to our docs{" "}
+            <a
+              className="text-cyan-400"
+              href="https://era.zksync.io/docs/reference/concepts/aa.html#general-paymaster-flow"
+            >
+              here.
+            </a>
+          </p>
+        </>
+      );
       break;
     case "Gasless Paymaster 🆓":
-      message =
-        <><p>You've selected the Gasless Paymaster. Things are going to be cheap for you!</p> <br/><p className="flex-wrap max-w-4xl	">The Gasless Paymaster uses the <span className="font-bold">general paymaster flow</span> which should be used if no prior actions are required from the user for the paymaster to operate. For more information, proceed to our docs <a className="text-cyan-400" href="https://era.zksync.io/docs/reference/concepts/aa.html#general-paymaster-flow">here.</a></p></>;
+      message = (
+        <>
+          <p>
+            You've selected the Gasless Paymaster. Things are going to be cheap
+            for you!
+          </p>{" "}
+          <br />
+          <p className="flex-wrap max-w-4xl	">
+            The Gasless Paymaster uses the{" "}
+            <span className="font-bold">general paymaster flow</span> which
+            should be used if no prior actions are required from the user for
+            the paymaster to operate. For more information, proceed to our docs{" "}
+            <a
+              className="text-cyan-400"
+              href="https://era.zksync.io/docs/reference/concepts/aa.html#general-paymaster-flow"
+            >
+              here.
+            </a>
+          </p>
+        </>
+      );
       break;
     case "ERC20Fixed Paymaster 🎫":
-      message =
-        <><p>You've selected the ERC20Fixed Paymaster. You will need to input the token contract address that is required for the paymaster.</p> <br/><p className="flex-wrap max-w-4xl	">The ERC20Fixed Paymaster uses the <span className="font-bold">approval-based paymaster flow</span> which should be used if the user is required to set certain allowance to a token for the paymaster to operate. For more information, proceed to our docs <a className="text-cyan-400" href="https://era.zksync.io/docs/reference/concepts/aa.html#built-in-paymaster-flows">here.</a></p></>;
+      message = (
+        <>
+          <p>
+            You've selected the ERC20Fixed Paymaster. You will need to input the
+            token contract address that is required for the paymaster.
+          </p>{" "}
+          <br />
+          <p className="flex-wrap max-w-4xl	">
+            The ERC20Fixed Paymaster uses the{" "}
+            <span className="font-bold">approval-based paymaster flow</span>{" "}
+            which should be used if the user is required to set certain
+            allowance to a token for the paymaster to operate. For more
+            information, proceed to our docs{" "}
+            <a
+              className="text-cyan-400"
+              href="https://era.zksync.io/docs/reference/concepts/aa.html#built-in-paymaster-flows"
+            >
+              here.
+            </a>
+          </p>
+        </>
+      );
       additionalInputNeeded = true;
       break;
     case "ERC721Gated Paymaster 🎨":
-      message =
-        <><p>You've selected the ERC721Gated Paymaster. You will need to input the NFT contract address that is gating the paymaster.</p> <br/><p className="flex-wrap max-w-4xl	">The ERC721Gated Paymaster uses the <span className="font-bold">general paymaster flow</span> which should be used if no prior actions are required from the user for the paymaster to operate. For more information, proceed to our docs <a className="text-cyan-400" href="https://era.zksync.io/docs/reference/concepts/aa.html#general-paymaster-flow">here.</a></p></>;
+      message = (
+        <>
+          <p>
+            You've selected the ERC721Gated Paymaster. You will need to input
+            the NFT contract address that is gating the paymaster.
+          </p>{" "}
+          <br />
+          <p className="flex-wrap max-w-4xl	">
+            The ERC721Gated Paymaster uses the{" "}
+            <span className="font-bold">general paymaster flow</span> which
+            should be used if no prior actions are required from the user for
+            the paymaster to operate. For more information, proceed to our docs{" "}
+            <a
+              className="text-cyan-400"
+              href="https://era.zksync.io/docs/reference/concepts/aa.html#general-paymaster-flow"
+            >
+              here.
+            </a>
+          </p>
+        </>
+      );
       additionalInputNeeded = true;
       break;
     default:

--- a/frontend/src/components/TxDetails.js
+++ b/frontend/src/components/TxDetails.js
@@ -15,9 +15,23 @@ const TxDetails = ({ txHash, signer, initialSignerBalance }) => {
   return (
     <div className="ml-8 mt-8">
       <h1 className="text-3xl font-bold mb-4">Transaction details:</h1>
-      <p className="text-2xl mb-4">Transaction Hash: <a href={`${TESTNET_EXPLORER_URL}${txHash}`} className="text-blue-500 underline">{txHash}</a></p>
-      <p className="text-2xl mb-4">Signer Initial Balance: <span className="font-bold">{initialSignerBalance}</span> </p>
-      <p className="text-2xl mb-4">Signer Balance After: <span className="font-bold">{signerBalanceAfter}</span></p>
+      <p className="text-2xl mb-4">
+        Transaction Hash:{" "}
+        <a
+          href={`${TESTNET_EXPLORER_URL}${txHash}`}
+          className="text-blue-500 underline"
+        >
+          {txHash}
+        </a>
+      </p>
+      <p className="text-2xl mb-4">
+        Signer Initial Balance:{" "}
+        <span className="font-bold">{initialSignerBalance}</span>{" "}
+      </p>
+      <p className="text-2xl mb-4">
+        Signer Balance After:{" "}
+        <span className="font-bold">{signerBalanceAfter}</span>
+      </p>
     </div>
   );
 };

--- a/frontend/src/constants/consts.js
+++ b/frontend/src/constants/consts.js
@@ -11,4 +11,4 @@ export const ERC721_GATED_PAYMASTER = "ERC721Gated Paymaster 🎨";
 export const ERC20_GATED_PAYMASTER = "ERC20Fixed Paymaster 🎫";
 export const GASLESS_PAYMASTER = "Gasless Paymaster 🆓";
 export const ALLOWLIST_PAYMASTER = "Allowlist Paymaster 📜";
-export const TESTNET_EXPLORER_URL = "https://goerli.explorer.zksync.io/tx/"
+export const TESTNET_EXPLORER_URL = "https://goerli.explorer.zksync.io/tx/";


### PR DESCRIPTION
This PR adds throwing of errors for test cases that seek a thrown error but would otherwise pass if no errors were to be thrown. 

Note:
Tests would fail on my machine locally after running `yarn test:contracts` with the following error: `Error: invalid hexlify value (argument="value", value="", code=INVALID_ARGUMENT, version=bytes/5.7.0)` and still fail with the same error after these changes. 