### PR TITLE
chore: add tests for paymaster contracts using era-test-node-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: run
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  tests:
+    name: unit-tests
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    
+    - name: Run Era Test Node
+      uses: dutterbutter/era-test-node-action@latest
+
+    - name: Install Dependencies
+      run: yarn install
+    
+    - name: Run Tests
+      run: |
+        yarn ci:tests

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -5,29 +5,39 @@ import "@matterlabs/hardhat-zksync-solc";
 import "@matterlabs/hardhat-zksync-verify";
 import "@nomiclabs/hardhat-etherscan";
 
-// dynamically changes endpoints for local tests
-const zkSyncTestnet =
-  process.env.NODE_ENV == "test"
-    ? {
+const getNetworkConfig = () => {
+  const env = process.env.DEPLOY_ENV || 'local';
+  switch (env) {
+    case 'local':
+      return {
         url: "http://localhost:3050",
         ethNetwork: "http://localhost:8545",
         zksync: true,
-        // Verification endpoint for Goerli
-        verifyURL:
-          "https://zksync2-testnet-explorer.zksync.dev/contract_verification",
-      }
-    : {
+      };
+    case 'ci':
+      return {
+        url: "http://127.0.0.1:8011",
+        ethNetwork: "goerli",
+        zksync: true,
+      };
+    case 'testnet':
+      return {
         url: "https://zksync2-testnet.zksync.dev",
         ethNetwork: "goerli",
         zksync: true,
         // Verification endpoint for Goerli
-        verifyURL:
-          "https://zksync2-testnet-explorer.zksync.dev/contract_verification",
+        verifyURL: "https://zksync2-testnet-explorer.zksync.dev/contract_verification",
       };
+    default:
+      throw new Error(`Unsupported DEPLOY_ENV: ${env}`);
+  }
+};
+
+const networkConfig = getNetworkConfig();
 
 const config: HardhatUserConfig = {
   zksolc: {
-    version: "latest", // can be defined like 1.3.x
+    version: "latest",
     settings: {},
   },
   defaultNetwork: "zkSyncTestnet",
@@ -35,7 +45,7 @@ const config: HardhatUserConfig = {
     hardhat: {
       zksync: false,
     },
-    zkSyncTestnet,
+    zkSyncTestnet: networkConfig,
   },
   solidity: {
     version: "0.8.17",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -25,7 +25,8 @@
     "zksync-web3": "^0.14.3"
   },
   "scripts": {
-    "test": "NODE_ENV=test hardhat test --network zkSyncTestnet",
+    "test": "NODE_ENV=local hardhat test --network zkSyncTestnet",
+    "ci:tests": "DEPLOY_ENV=ci hardhat test --network zkSyncTestnet --show-stack-traces",
     "deploy": "hardhat deploy-zksync",
     "greeter": "hardhat deploy-zksync --script greeter.ts",
     "gasless": "hardhat deploy-zksync --script gaslessPaymaster.ts",

--- a/contracts/test/erc20fixed.test.ts
+++ b/contracts/test/erc20fixed.test.ts
@@ -11,7 +11,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 // load wallet private key from env file
-const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110";
 
 describe("ERC20fixedPaymaster", function () {
   let provider: Provider;
@@ -25,7 +25,7 @@ describe("ERC20fixedPaymaster", function () {
 
   before(async function () {
     // setup deployer
-    provider = Provider.getDefaultProvider();
+    provider = new Provider("http://127.0.0.1:8011");
     wallet = new Wallet(PRIVATE_KEY, provider);
     deployer = new Deployer(hre, wallet);
     // setup new wallet

--- a/contracts/test/erc721gated.test.ts
+++ b/contracts/test/erc721gated.test.ts
@@ -11,7 +11,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 // load wallet private key from env file
-const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110";
 
 describe("ERC721gatedPaymaster", function () {
   let provider: Provider;
@@ -26,7 +26,7 @@ describe("ERC721gatedPaymaster", function () {
 
   before(async function () {
     // setup deployer
-    provider = Provider.getDefaultProvider();
+    provider = new Provider("http://127.0.0.1:8011");
     wallet = new Wallet(PRIVATE_KEY, provider);
     deployer = new Deployer(hre, wallet);
 

--- a/contracts/test/gasless.test.ts
+++ b/contracts/test/gasless.test.ts
@@ -11,7 +11,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 // load wallet private key from env file
-const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110";
 
 describe("GaslessPaymaster", function () {
   let provider: Provider;
@@ -25,7 +25,7 @@ describe("GaslessPaymaster", function () {
 
   before(async function () {
     // setup deployer
-    provider = Provider.getDefaultProvider();
+    provider = new Provider("http://127.0.0.1:8011");
     wallet = new Wallet(PRIVATE_KEY, provider);
     deployer = new Deployer(hre, wallet);
     // setup new wallet

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "scripts": {
     "test:contracts": "yarn workspace contracts test",
+    "ci:tests": "yarn workspace contracts ci:tests",
     "deploy:contracts": "yarn workspace contracts deploy", 
     "compile:contracts": "yarn workspace contracts compile",
     "deploy:greeter": "yarn workspace contracts greeter",


### PR DESCRIPTION
Changes introduced in this PR: 
- Adds test suite to CI/CD pipeline for contracts 
- Adds dedicated cmd for ci tests 
- Updates hardhat config to add dynamic network configs 