### PR TITLE
fix: update .gitignore to exclude yarn files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,16 @@ typings/
 # Output of 'npm pack'
 *.tgz
 
-# Yarn Integrity file
+# Yarn
 .yarn-integrity
+.yarn/*
+.yarn/install-state.gz
+!.yarn/cache
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 
 # dotenv environment variables file
 .env

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
As seen in `README.md.`,  this project is currently using `yarn` as the package manager, but it appears that the gitignore file is not fully complying with the latest guidelines of yarn. 

The purpose of this PR is to modify the `.gitignore` file as recommended in the official documents of yarn regarding what should be ignored and what should be committed. 

Reference: https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored