### PR TITLE
feat: add zkSync era mainnet to hardhat config

### DIFF
--- a/contracts/deploy/allowListPaymaster.ts
+++ b/contracts/deploy/allowListPaymaster.ts
@@ -1,8 +1,7 @@
 import { Provider, Wallet } from "zksync-web3";
 import * as ethers from "ethers";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { HardhatRuntimeEnvironment, HttpNetworkUserConfig } from "hardhat/types";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
-import { HttpNetworkUserConfig } from "hardhat/types";
 
 // load env file
 import dotenv from "dotenv";
@@ -17,9 +16,7 @@ if (!PRIVATE_KEY)
 
 export default async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Running deploy script for the AllowlistPaymaster contract...`);
-  // Currently targeting the Sepolia zkSync testnet
-  const network = hre.userConfig.networks?.zkSyncTestnet;
-  const provider = new Provider((network as HttpNetworkUserConfig).url);
+  const provider = new Provider((hre.network.config as HttpNetworkUserConfig).url);
 
   // The wallet that will deploy the token and the paymaster
   // It is assumed that this wallet already has sufficient funds on zkSync

--- a/contracts/deploy/erc20fixedPaymaster.ts
+++ b/contracts/deploy/erc20fixedPaymaster.ts
@@ -24,9 +24,7 @@ if (!TOKEN_ADDRESS)
 
 export default async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Running deploy script for the ERC20fixedPaymaster contract...`);
-  // Currently targeting the Sepolia zkSync testnet
-  const network = hre.userConfig.networks?.zkSyncTestnet;
-  const provider = new Provider((network as HttpNetworkUserConfig).url);
+  const provider = new Provider((hre.network.config as HttpNetworkUserConfig).url);
   // The wallet that will deploy the token and the paymaster
   // It is assumed that this wallet already has sufficient funds on zkSync
   const wallet = new Wallet(PRIVATE_KEY);

--- a/contracts/deploy/erc721gatedPaymaster.ts
+++ b/contracts/deploy/erc721gatedPaymaster.ts
@@ -23,9 +23,7 @@ if (!NFT_COLLECTION_ADDRESS)
 
 export default async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Running deploy script for the ERC721gatedPaymaster contract...`);
-  // Currently targeting the Sepolia zkSync testnet
-  const network = hre.userConfig.networks?.zkSyncTestnet;
-  const provider = new Provider((network as HttpNetworkUserConfig).url);
+  const provider = new Provider((hre.network.config as HttpNetworkUserConfig).url);
 
   // The wallet that will deploy the token and the paymaster
   // It is assumed that this wallet already has sufficient funds on zkSync

--- a/contracts/deploy/gaslessPaymaster.ts
+++ b/contracts/deploy/gaslessPaymaster.ts
@@ -18,9 +18,7 @@ if (!PRIVATE_KEY)
 
 export default async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Running deploy script for the GaslessPaymaster contract...`);
-  // Currently targeting the Sepolia zkSync testnet
-  const network = hre.userConfig.networks?.zkSyncTestnet;
-  const provider = new Provider((network as HttpNetworkUserConfig).url);
+  const provider = new Provider((hre.network.config as HttpNetworkUserConfig).url);
   // The wallet that will deploy the token and the paymaster
   // It is assumed that this wallet already has sufficient funds on zkSync
   const wallet = new Wallet(PRIVATE_KEY);

--- a/contracts/deploy/timeBasedPaymaster.ts
+++ b/contracts/deploy/timeBasedPaymaster.ts
@@ -18,9 +18,7 @@ if (!PRIVATE_KEY)
 
 export default async function (hre: HardhatRuntimeEnvironment) {
   console.log(`Running deploy script for the TimeBasedPaymaster contract...`);
-  // Currently targeting the Sepolia zkSync testnet
-  const network = hre.userConfig.networks?.zkSyncTestnet;
-  const provider = new Provider((network as HttpNetworkUserConfig).url);
+  const provider = new Provider((hre.network.config as HttpNetworkUserConfig).url);
 
   const wallet = new Wallet(PRIVATE_KEY);
   const deployer = new Deployer(hre, wallet);

--- a/contracts/deploy/use-greeter.ts
+++ b/contracts/deploy/use-greeter.ts
@@ -1,6 +1,6 @@
 import { Provider } from "zksync-web3";
 import * as ethers from "ethers";
-import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { HardhatRuntimeEnvironment, HttpNetworkUserConfig } from "hardhat/types";
 
 // load env file
 import dotenv from "dotenv";
@@ -14,7 +14,7 @@ const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
 if (!PRIVATE_KEY)
   throw "⛔️ Private key not detected! Add it to the .env file!";
 
-// Address of the contract on zksync testnet
+// Address of the greeter contract on zksync
 const CONTRACT_ADDRESS = "";
 
 if (!CONTRACT_ADDRESS) throw "⛔️ Contract address not provided";
@@ -25,7 +25,7 @@ export default async function (hre: HardhatRuntimeEnvironment) {
 
   // Initialize the provider.
   // @ts-ignore
-  const provider = new Provider(hre.userConfig.networks?.zkSyncTestnet?.url);
+  const provider = new Provider((hre.network.config as HttpNetworkUserConfig).url);
   const signer = new ethers.Wallet(PRIVATE_KEY, provider);
 
   // Initialise contract instance

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -33,6 +33,12 @@ const config: HardhatUserConfig = {
       verifyURL:
         "https://explorer.sepolia.era.zksync.dev/contract_verification",
     },
+    zkSyncMainnet: {
+      url: "https://mainnet.era.zksync.io",
+      ethNetwork: "mainnet",
+      zksync: true,
+      verifyURL: "https://zksync2-mainnet-explorer.zksync.io/contract_verification",
+    },
   },
   solidity: {
     version: "0.8.17",


### PR DESCRIPTION
After experimenting with paymaster-examples, I realized that we could not deploy the contract to the mainnet due to missing hardhat configuration. 

This PR is about adding zkSync Era Mainnet to the `hardhat.config.ts` to allow the deployment to mainnet. Also, update all deployment scripts to get the default network context from `HardhatRuntimeEnv` instead of hard-coded to testnet.