### PR TITLE
added ERC721AndDestinationgatedPaymaster example

### DIFF
--- a/contracts/contracts/paymasters/ERC721AndDestinationgatedPaymaster.sol
+++ b/contracts/contracts/paymasters/ERC721AndDestinationgatedPaymaster.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+
+import {IPaymaster, ExecutionResult, PAYMASTER_VALIDATION_SUCCESS_MAGIC} from "@matterlabs/zksync-contracts/l2/system-contracts/interfaces/IPaymaster.sol";
+import {IPaymasterFlow} from "@matterlabs/zksync-contracts/l2/system-contracts/interfaces/IPaymasterFlow.sol";
+import {TransactionHelper, Transaction} from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/TransactionHelper.sol";
+
+import "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @author Matter Labs
+/// @notice This smart contract pays the gas fees on behalf of users that are the owner of a specific NFT asset
+contract ERC721AndDestinationgatedPaymaster is IPaymaster, Ownable {
+    IERC721 private immutable nft_asset;
+
+    //store whitelisted contract addresses
+    mapping(address => bool) public whitelistedContracts;
+
+    modifier onlyBootloader() {
+        require(
+            msg.sender == BOOTLOADER_FORMAL_ADDRESS,
+            "Only bootloader can call this method"
+        );
+        // Continue execution if called from the bootloader.
+        _;
+    }
+
+    // The constructor takes the address of the ERC721 contract as an argument.
+    // The ERC721 contract is the asset that the user must hold in order to use the paymaster.
+    constructor(address _erc721) {
+        nft_asset = IERC721(_erc721); // Initialize the ERC721 contract
+    }
+
+    function addWhitelisedContract(address whitelistedContractAddress) external onlyOwner {
+        whitelistedContracts[whitelistedContractAddress] = true;
+    }
+
+    function removeWhitelisedContract(address removedContractAddress) external onlyOwner {
+        whitelistedContracts[removedContractAddress] = false;
+    }
+
+    // The gas fees will be paid for by the paymaster if the user is the owner of the required NFT asset.
+    function validateAndPayForPaymasterTransaction(
+        bytes32,
+        bytes32,
+        Transaction calldata _transaction
+    )
+        external
+        payable
+        onlyBootloader
+        returns (bytes4 magic, bytes memory context)
+    {
+        // By default we consider the transaction as accepted.
+        magic = PAYMASTER_VALIDATION_SUCCESS_MAGIC;
+        require(
+            _transaction.paymasterInput.length >= 4,
+            "The standard paymaster input must be at least 4 bytes long"
+        );
+
+        bytes4 paymasterInputSelector = bytes4(
+            _transaction.paymasterInput[0:4]
+        );
+
+        // Use the general paymaster flow
+        if (paymasterInputSelector == IPaymasterFlow.general.selector) {
+            address userAddress = address(uint160(_transaction.from));
+            address destinationContract = address(uint160(_transaction.to)); 
+            // Verify if user has the required NFT asset in order to use paymaster
+            require(
+                nft_asset.balanceOf(userAddress) > 0,
+                "User does not hold the required NFT asset and therefore must for their own gas!"
+            );
+            // Verity that the destination contract is the one we want to cover gas for
+            require(
+                whitelistedContracts[destinationContract],
+                "Destination smart contract not whitelisted"
+            );
+            // Note, that while the minimal amount of ETH needed is tx.gasPrice * tx.gasLimit,
+            // neither paymaster nor account are allowed to access this context variable.
+            uint256 requiredETH = _transaction.gasLimit *
+                _transaction.maxFeePerGas;
+
+            // The bootloader never returns any data, so it can safely be ignored here.
+            (bool success, ) = payable(BOOTLOADER_FORMAL_ADDRESS).call{
+                value: requiredETH
+            }("");
+        } else {
+            revert("Invalid paymaster flow");
+        }
+    }
+
+    function postTransaction(
+        bytes calldata _context,
+        Transaction calldata _transaction,
+        bytes32,
+        bytes32,
+        ExecutionResult _txResult,
+        uint256 _maxRefundedGas
+    ) external payable override onlyBootloader {
+        // Refunds are not supported yet.
+    }
+
+    function withdraw(address payable _to) external onlyOwner {
+        // send paymaster funds to the owner
+        uint256 balance = address(this).balance;
+        (bool success, ) = _to.call{value: balance}("");
+        require(success, "Failed to withdraw funds from paymaster.");
+    }
+
+    receive() external payable {}
+}

--- a/contracts/deploy/ERC721AndDestinationgated.ts
+++ b/contracts/deploy/ERC721AndDestinationgated.ts
@@ -1,0 +1,71 @@
+import { Provider, Wallet } from "zksync-web3";
+import * as ethers from "ethers";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
+
+// load env file
+import dotenv from "dotenv";
+dotenv.config();
+
+// load wallet private key from env file
+const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+// The address of the NFT collection contract
+const NFT_COLLECTION_ADDRESS = "ADDRESS_OF_NFT_COLLECTION_CONTRACT";
+
+if (!PRIVATE_KEY)
+  throw "⛔️ Private key not detected! Add it to the .env file!";
+
+if (!NFT_COLLECTION_ADDRESS)
+  throw "⛔️ NFT_COLLECTION_ADDRESS not detected! Add it to the NFT_COLLECTION_ADDRESS variable!";
+
+export default async function (hre: HardhatRuntimeEnvironment) {
+  console.log(`Running deploy script for the ERC721AndDestinationgatedPaymaster contract...`);
+  const provider = new Provider("https://testnet.era.zksync.dev");
+
+  // The wallet that will deploy the token and the paymaster
+  // It is assumed that this wallet already has sufficient funds on zkSync
+  const wallet = new Wallet(PRIVATE_KEY);
+  const deployer = new Deployer(hre, wallet);
+
+  // Deploying the paymaster
+  const paymasterArtifact = await deployer.loadArtifact("ERC721AndDestinationgatedPaymaster");
+  const deploymentFee = await deployer.estimateDeployFee(paymasterArtifact, [
+    NFT_COLLECTION_ADDRESS,
+  ]);
+  const parsedFee = ethers.utils.formatEther(deploymentFee.toString());
+  console.log(`The deployment is estimated to cost ${parsedFee} ETH`);
+  // Deploy the contract
+  const paymaster = await deployer.deploy(paymasterArtifact, [
+    NFT_COLLECTION_ADDRESS,
+  ]);
+  console.log(`Paymaster address: ${paymaster.address}`);
+
+  console.log("Funding paymaster with ETH");
+  // Supplying paymaster with ETH
+  await (
+    await deployer.zkWallet.sendTransaction({
+      to: paymaster.address,
+      value: ethers.utils.parseEther("0.005"),
+    })
+  ).wait();
+
+  let paymasterBalance = await provider.getBalance(paymaster.address);
+  console.log(`Paymaster ETH balance is now ${paymasterBalance.toString()}`);
+
+  // Verify contract programmatically
+  //
+  // Contract MUST be fully qualified name (e.g. path/sourceName:contractName)
+  const contractFullyQualifedName =
+    "contracts/paymasters/ERC721AndDestinationgatedPaymaster.sol:ERC721AndDestinationgatedPaymaster";
+  const verificationId = await hre.run("verify:verify", {
+    address: paymaster.address,
+    contract: contractFullyQualifedName,
+    constructorArguments: [NFT_COLLECTION_ADDRESS],
+    bytecode: paymasterArtifact.bytecode,
+  });
+  console.log(
+    `${contractFullyQualifedName} verified! VerificationId: ${verificationId}`,
+  );
+
+  console.log(`Done!`);
+}

--- a/contracts/test/ERC721AndDestinationgated.test.ts
+++ b/contracts/test/ERC721AndDestinationgated.test.ts
@@ -1,0 +1,112 @@
+import { expect } from "chai";
+import { Wallet, Provider, Contract, utils } from "zksync-web3";
+import * as hre from "hardhat";
+import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
+import * as ethers from "ethers";
+
+import { deployContract, fundAccount } from "./utils";
+
+// load env file
+import dotenv from "dotenv";
+dotenv.config();
+
+// load wallet private key from env file
+const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+
+describe("ERC721gatedPaymaster", function () {
+  let provider: Provider;
+  let wallet: Wallet;
+  let deployer: Deployer;
+  let userWallet: Wallet;
+  let initialBalance: ethers.BigNumber;
+  let otherBalance: ethers.BigNumber;
+  let paymaster: Contract;
+  let greeter: Contract;
+  let erc721: Contract;
+
+  before(async function () {
+    // setup deployer
+    provider = Provider.getDefaultProvider();
+    wallet = new Wallet(PRIVATE_KEY, provider);
+    deployer = new Deployer(hre, wallet);
+
+    // setup new wallet
+    userWallet = Wallet.createRandom();
+    userWallet = new Wallet(userWallet.privateKey, provider);
+    initialBalance = await userWallet.getBalance();
+    // deploy contracts
+    erc721 = await deployContract(deployer, "MyNFT", []);
+    paymaster = await deployContract(deployer, "ERC721AndDestinationgatedPaymaster", [
+      erc721.address,
+    ]);
+    greeter = await deployContract(deployer, "Greeter", ["Hi"]);
+    // fund paymaster
+    await fundAccount(wallet, paymaster.address, "3");
+    otherBalance = await wallet.getBalance();
+  });
+
+  async function executeGreetingTransaction(user: Wallet) {
+    const gasPrice = await provider.getGasPrice();
+
+    const paymasterParams = utils.getPaymasterParams(paymaster.address, {
+      type: "General",
+      // empty bytes as paymaster does not use innerInput
+      innerInput: new Uint8Array(),
+    });
+    console.log("user: ", user.address);
+    const setGreetingTx = await greeter
+      .connect(user)
+      .setGreeting("Hello World", {
+        maxPriorityFeePerGas: ethers.BigNumber.from(0),
+        maxFeePerGas: gasPrice,
+        // hardhcoded for testing
+        gasLimit: 6000000,
+        customData: {
+          gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+          paymasterParams,
+        },
+      });
+
+    await setGreetingTx.wait();
+
+    return wallet.getBalance();
+  }
+
+  it("should not pay for gas fees when user has NFT and greeter contract is whilteisted", async function () {
+    const tx = await erc721
+      .connect(wallet)
+      .createCollectible(userWallet.address);
+    await tx.wait();
+    const whitelistTx = await paymaster
+      .connect(wallet)
+      .addWhitelisedContract(greeter.address);
+    await whitelistTx.wait()
+
+    await executeGreetingTransaction(userWallet);
+    const newBalance = await userWallet.getBalance();
+
+    expect(await greeter.greet()).to.equal("Hello World");
+    expect(newBalance).to.eql(initialBalance);
+  });
+
+  it("should allow owner to withdraw all funds", async function () {
+    try {
+      const tx = await paymaster.connect(wallet).withdraw(userWallet.address);
+      await tx.wait();
+    } catch (e) {
+      console.error("Error executing withdrawal:", e);
+    }
+
+    const finalContractBalance = await provider.getBalance(paymaster.address);
+
+    expect(finalContractBalance).to.eql(ethers.BigNumber.from(0));
+  });
+
+  it("should prevent non-owners from withdrawing funds", async function () {
+    try {
+      await paymaster.connect(userWallet).withdraw(userWallet.address);
+    } catch (e) {
+      expect(e.message).to.include("Ownable: caller is not the owner");
+    }
+  });
+});

--- a/contracts/test/ERC721AndDestinationgated.test.ts
+++ b/contracts/test/ERC721AndDestinationgated.test.ts
@@ -1,10 +1,10 @@
 import { expect } from "chai";
 import { Wallet, Provider, Contract, utils } from "zksync-web3";
-import * as hre from "hardhat";
 import { Deployer } from "@matterlabs/hardhat-zksync-deploy";
 import * as ethers from "ethers";
+import hardhatConfig from "../hardhat.config";
 
-import { deployContract, fundAccount } from "./utils";
+import { deployContract, fundAccount, setupDeployer } from "./utils";
 
 // load env file
 import dotenv from "dotenv";
@@ -13,7 +13,7 @@ dotenv.config();
 // load wallet private key from env file
 const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110";
 
-describe("ERC721gatedPaymaster", function () {
+describe("ERC721AndDestinationgated", function () {
   let provider: Provider;
   let wallet: Wallet;
   let deployer: Deployer;
@@ -25,10 +25,9 @@ describe("ERC721gatedPaymaster", function () {
   let erc721: Contract;
 
   before(async function () {
+    const deployUrl = hardhatConfig.networks.zkSyncInMemory.url;
     // setup deployer
-    provider = Provider.getDefaultProvider();
-    wallet = new Wallet(PRIVATE_KEY, provider);
-    deployer = new Deployer(hre, wallet);
+    [provider, wallet, deployer] = setupDeployer(deployUrl, PRIVATE_KEY);
 
     // setup new wallet
     userWallet = Wallet.createRandom();

--- a/contracts/test/ERC721AndDestinationgated.test.ts
+++ b/contracts/test/ERC721AndDestinationgated.test.ts
@@ -11,7 +11,7 @@ import dotenv from "dotenv";
 dotenv.config();
 
 // load wallet private key from env file
-const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "0x7726827caac94a7f9e1b160f7ea819f172f7b6f9d2a97f992c38edeab82d4110";
 
 describe("ERC721gatedPaymaster", function () {
   let provider: Provider;


### PR DESCRIPTION
This paymaster gates (a) by whether or not caller has the required ERC721 NFT and (b) by whether or not destination smart contract is whitelisted. 