### PR TITLE
feat: adds application paymaster

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -8,6 +8,7 @@ This repository contains several example Paymaster Smart Contracts that cover mo
 
 - 🆓 **[Gasless Paymaster](./contracts/paymasters/GaslessPaymaster.sol)**: Pays fees for any account.
 - 📜 **[Allowlist Paymaster](./contracts/paymasters/AllowlistPaymaster.sol)**: Pays fees for accounts present in a predefined list (the "allow list").
+- 📜 **[Application Paymaster](./contracts/paymasters/ApplicationPaymaster.sol)**: Pays fees for transactions targeting and allowed contract and function selector.
 - 🎫 **[ERC20 Fixed Paymaster](./contracts/paymasters/ERC20fixedPaymaster.sol)**: Accepts a fixed amount of a specific ERC20 token in exchange for covering gas fees. It only services accounts that have a balance of the specified token. 
 - 🎨 **[ERC721 Gated Paymaster](./contracts/paymasters/ERC721gatedPaymaster.sol)**: Pays fees for accounts that hold a specific ERC721 token (NFT).
 - 🎨 **[TimeBased Paymaster](./contracts/paymasters/TimeBasedPaymaster.sol)**: Pays fees for accounts that interact with contract at specific times.

--- a/contracts/contracts/paymasters/ApplicationPaymaster.sol
+++ b/contracts/contracts/paymasters/ApplicationPaymaster.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IPaymaster, ExecutionResult, PAYMASTER_VALIDATION_SUCCESS_MAGIC} from "@matterlabs/zksync-contracts/l2/system-contracts/interfaces/IPaymaster.sol";
+import {IPaymasterFlow} from "@matterlabs/zksync-contracts/l2/system-contracts/interfaces/IPaymasterFlow.sol";
+import {TransactionHelper, Transaction} from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/TransactionHelper.sol";
+
+import "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @author Matter Labs
+/// @notice This contract validates that the transaction is targeted towards a defined application
+/// contract and function selector. It also ensures that the paymaster flow is correct.
+contract ApplicationPaymaster is IPaymaster, Ownable {
+  address public immutable APPLICATION_CONTRACT_ADDRESS;
+  bytes4 public constant FUNCTION_SELECTOR =
+    bytes4(keccak256("setGreeting(string)"));
+
+  modifier onlyBootloader() {
+    require(
+      msg.sender == BOOTLOADER_FORMAL_ADDRESS,
+      "Only bootloader can call this method"
+    );
+    // Continue execution if called from the bootloader.
+    _;
+  }
+
+  constructor(address applicationContractAddress) {
+    APPLICATION_CONTRACT_ADDRESS = applicationContractAddress;
+  }
+
+  function validateAndPayForPaymasterTransaction(
+    bytes32,
+    bytes32,
+    Transaction calldata _transaction
+  )
+    external
+    payable
+    onlyBootloader
+    returns (bytes4 magic, bytes memory context)
+  {
+    // By default we consider the transaction as accepted.
+    magic = PAYMASTER_VALIDATION_SUCCESS_MAGIC;
+    require(
+      _transaction.paymasterInput.length >= 4,
+      "The standard paymaster input must be at least 4 bytes long"
+    );
+
+    // Ensure the transaction is calling the application contract
+    require(
+      address(uint160(_transaction.to)) == APPLICATION_CONTRACT_ADDRESS,
+      "Unsupported contract address"
+    );
+    // Ensure the transaction is calling the allowed function selector
+    require(_transaction.data.length >= 4, "Transaction data is too short");
+    bytes4 methodSelector = bytes4(_transaction.data[0:4]);
+    require(methodSelector == FUNCTION_SELECTOR, "Unsupported method");
+
+    bytes4 paymasterInputSelector = bytes4(_transaction.paymasterInput[0:4]);
+    if (paymasterInputSelector == IPaymasterFlow.general.selector) {
+      // Note, that while the minimal amount of ETH needed is tx.gasPrice * tx.gasLimit,
+      // neither paymaster nor account are allowed to access this context variable.
+      uint256 requiredETH = _transaction.gasLimit * _transaction.maxFeePerGas;
+
+      // The bootloader never returns any data, so it can safely be ignored here.
+      (bool success, ) = payable(BOOTLOADER_FORMAL_ADDRESS).call{
+        value: requiredETH
+      }("");
+      require(
+        success,
+        "Failed to transfer tx fee to the Bootloader. Paymaster balance might not be enough."
+      );
+    } else {
+      revert("Unsupported paymaster flow in paymasterParams.");
+    }
+  }
+
+  function postTransaction(
+    bytes calldata _context,
+    Transaction calldata _transaction,
+    bytes32,
+    bytes32,
+    ExecutionResult _txResult,
+    uint256 _maxRefundedGas
+  ) external payable override onlyBootloader {}
+
+  function withdraw(address payable _to) external onlyOwner {
+    uint256 balance = address(this).balance;
+    (bool success, ) = _to.call{value: balance}("");
+    require(success, "Failed to withdraw funds from paymaster.");
+  }
+
+  receive() external payable {}
+}

--- a/contracts/deploy/applicationPaymaster.ts
+++ b/contracts/deploy/applicationPaymaster.ts
@@ -1,0 +1,65 @@
+import { fundAccount, deployContract } from "./utils";
+import * as hre from "hardhat";
+
+// load env file
+import dotenv from "dotenv";
+dotenv.config();
+
+// load wallet private key from env file
+const PRIVATE_KEY = process.env.WALLET_PRIVATE_KEY || "";
+
+if (!PRIVATE_KEY)
+  throw "⛔️ Private key not detected! Add it to the .env file!";
+
+async function main() {
+  const contract = "ApplicationPaymaster";
+  // Application contract address
+  const appContractAddress = "";
+  const artifact = await hre.ethers.loadArtifact(contract);
+
+  console.log(
+    `Running script to deploy ${artifact.contractName} contract on ${hre.network.name}`,
+  );
+
+  // Retrieve signers
+  const [deployer] = await hre.ethers.getSigners();
+
+  // Deploying the paymaster
+  const paymaster = await deployContract(artifact.contractName, [
+    appContractAddress,
+  ]);
+  const paymasterAddress = await paymaster.getAddress();
+  console.log(`Paymaster address: ${paymasterAddress}`);
+  console.log(`Application contract: ${appContractAddress}`);
+
+  console.log("Funding paymaster with ETH");
+  // Supplying paymaster with ETH
+  await fundAccount(deployer, paymasterAddress, "0.005");
+
+  const paymasterBalance = await hre.ethers.provider.getBalance(
+    paymasterAddress,
+  );
+  console.log(`Paymaster ETH balance is now ${paymasterBalance.toString()}`);
+
+  // only verify on testnet and mainnet
+  if (hre.network.name.includes("ZKsyncEra")) {
+    const verificationId = await hre.run("verify:verify", {
+      address: paymasterAddress,
+      // Contract MUST be fully qualified name (e.g. path/sourceName:contractName)
+      contract: `${artifact.sourceName}:${artifact.contractName}`,
+      constructorArguments: [appContractAddress],
+    });
+    console.log(
+      `${artifact.contractName} verified! VerificationId: ${verificationId}`,
+    );
+  }
+
+  console.log(`Done!`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -11,10 +11,7 @@ const TEST_RICH_WALLET =
   "0x3d3cbc973389cb26f657686445bcc75662b415b656078503592ac8c1abb8810e";
 
 const config: HardhatUserConfig = {
-  zksolc: {
-    version: "latest",
-    settings: {},
-  },
+  zksolc: {},
   defaultNetwork: "hardhat",
   networks: {
     hardhat: {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -26,6 +26,7 @@
     "ci:tests": "hardhat test --show-stack-traces",
     "greeter": "hardhat run ./deploy/greeter.ts",
     "gasless": "hardhat run ./deploy/gaslessPaymaster.ts",
+    "application": "hardhat run ./deploy/applicationPaymaster.ts",
     "allowList": "hardhat run ./deploy/allowListPaymaster.ts",
     "nftGated": "hardhat run ./deploy/erc721gatedPaymaster.ts",
     "fixedToken": "hardhat run ./deploy/erc20fixedPaymaster.ts",

--- a/contracts/test/application.test.ts
+++ b/contracts/test/application.test.ts
@@ -1,0 +1,139 @@
+import { expect } from "chai";
+import { Wallet, Provider, Contract, utils, Signer } from "zksync-ethers";
+import * as hre from "hardhat";
+
+import { deployContract, fundAccount } from "../deploy/utils";
+
+// load env file
+import dotenv from "dotenv";
+dotenv.config();
+
+describe.only("ApplicationPaymaster", function () {
+  let provider: Provider;
+  let randomWallet: any;
+  let emptyWallet: Wallet;
+  let wallet: Wallet;
+  let initialBalance: bigint;
+  let paymaster: Contract;
+  let paymasterAddress: string;
+  let greeter: Contract;
+  let greeterAddress: string;
+  let erc721: Contract;
+  let erc721Address: string;
+  let signers: Signer[];
+  let deployer: Signer;
+  let errorOccurred = false;
+
+  before(async function () {
+    // retrieve default signers
+    signers = await hre.ethers.getSigners();
+    deployer = signers[0];
+    // setup new empty wallet
+    randomWallet = Wallet.createRandom();
+    emptyWallet = new Wallet(randomWallet.privateKey, hre.ethers.provider);
+    initialBalance = await hre.ethers.provider.getBalance(emptyWallet.address);
+
+    // deploy contracts
+    greeter = await deployContract("Greeter", ["Hi"]);
+    greeterAddress = await greeter.getAddress();
+    erc721 = await deployContract("MyNFT", []);
+    erc721Address = await erc721.getAddress();
+    paymaster = await deployContract("ApplicationPaymaster", [greeterAddress]);
+    paymasterAddress = await paymaster.getAddress();
+    // fund paymaster
+    await fundAccount(deployer, paymasterAddress, "3");
+  });
+
+  async function executeGreetingTransaction(user: Wallet) {
+    const gasPrice = await hre.ethers.provider.getGasPrice();
+
+    const paymasterParams = utils.getPaymasterParams(paymasterAddress, {
+      type: "General",
+      // empty bytes as paymaster does not use innerInput
+      innerInput: new Uint8Array(),
+    });
+    const setGreetingTx = await greeter
+      .connect(user)
+      .setGreeting("Hello World", {
+        maxPriorityFeePerGas: 0n,
+        maxFeePerGas: gasPrice,
+        // hardcoded for testing
+        gasLimit: 6000000,
+        customData: {
+          gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+          paymasterParams,
+        },
+      });
+
+    await setGreetingTx.wait();
+  }
+
+  async function executeERC721Transaction(user: Wallet) {
+    const gasPrice = await hre.ethers.provider.getGasPrice();
+
+    const paymasterParams = utils.getPaymasterParams(paymasterAddress, {
+      type: "General",
+      // empty bytes as paymaster does not use innerInput
+      innerInput: new Uint8Array(),
+    });
+    const erc721Tx = await erc721
+      .connect(user)
+      .createCollectible(user.address, {
+        maxPriorityFeePerGas: 0n,
+        maxFeePerGas: gasPrice,
+        // hardcoded for testing
+        gasLimit: 6000000,
+        customData: {
+          gasPerPubdata: utils.DEFAULT_GAS_PER_PUBDATA_LIMIT,
+          paymasterParams,
+        },
+      });
+
+    await erc721Tx.wait();
+  }
+
+  it("should pay for gas fees when user calls allowed function selector", async function () {
+    await executeGreetingTransaction(emptyWallet);
+    const newBalance = await hre.ethers.provider.getBalance(
+      emptyWallet.address,
+    );
+
+    expect(await greeter.greet()).to.equal("Hello World");
+    expect(newBalance).to.eql(initialBalance);
+  });
+
+  it("should fail validation when user calls not allowed contract", async function () {
+    try {
+      await executeERC721Transaction(emptyWallet);
+    } catch (error) {
+      errorOccurred = true;
+      expect(error.message).to.include("Unsupported contract address");
+    }
+    expect(errorOccurred).to.be.true;
+  });
+
+  it("should allow owner to withdraw all funds", async function () {
+    try {
+      const tx = await paymaster
+        .connect(deployer)
+        .withdraw(emptyWallet.address);
+      await tx.wait();
+    } catch (e) {
+      console.error("Error executing withdrawal:", e);
+    }
+
+    const finalContractBalance = await hre.ethers.provider.getBalance(
+      paymasterAddress,
+    );
+
+    expect(finalContractBalance).to.eql(0n);
+  });
+
+  it("should prevent non-owners from withdrawing funds", async function () {
+    try {
+      await paymaster.connect(emptyWallet).withdraw(emptyWallet.address);
+    } catch (e) {
+      expect(e.message).to.include("Ownable: caller is not the owner");
+    }
+  });
+});


### PR DESCRIPTION
## What

- Adds `ApplicationPaymaster`. This paymaster pays transactions that target a specific contract address and function selector.
- Includes paymaster contract, tests, and deployment script.

## Why

This paymaster has bees requested a couple times by teams.